### PR TITLE
fix the little issue when $HOME/.ssh folder does not exist

### DIFF
--- a/storm/ssh_config.py
+++ b/storm/ssh_config.py
@@ -1,5 +1,7 @@
 # -*- coding: utf8 -*-
 
+from os import makedirs
+from os.path import dirname
 from os.path import expanduser
 from os.path import exists
 from paramiko.config import SSHConfig
@@ -67,6 +69,8 @@ class ConfigParser(object):
         self.ssh_config_file = ssh_config_file
 
         if not exists(self.ssh_config_file):
+            if not exists(dirname(self.ssh_config_file)):
+                makedirs(dirname(self.ssh_config_file))
             open(self.ssh_config_file, 'w+').close()
 
         self.config_data = []


### PR DESCRIPTION
this little patch tries to fix the issue when "$HOME/.ssh" folder does not exist.
this situation is quite common for users' environment - no "$HOME/.ssh" 
