### PR TITLE
Make argparse requirement necessary only for Python 2.6-

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from distutils.core import setup
 
 setup(
@@ -12,9 +14,9 @@ setup(
     scripts=[
         'storm/bin/storm'
     ],
-    install_requires=[
+    install_requires=list(filter(None, [
         "paramiko",
         "manage.py",
         "termcolor",
-        "argparse",
-    ],)
+        "argparse" if sys.version_info[:2] < (2, 7) else None,
+    ])),)


### PR DESCRIPTION
As argparse is part of standard library in Python 2.7+ it's no sense to install fallback requirement to system scope.

Commit also works with Python 3 by explicitly casting filter iterable to list.
