### PR TITLE
added additional plural() check so page is updated with correct data

### DIFF
--- a/storm/static/js/main.js
+++ b/storm/static/js/main.js
@@ -87,11 +87,10 @@ function Storm($scope, $http) {
               title: $scope.title,
               uri: $scope.uri
             });
-            plural();
             $scope.title = $scope.uri = "";
             $scope.state.action = "add new";
             focus();
-            fetch();
+            fetch(plural);
           } else {
             alert("something wrong...");
           }


### PR DESCRIPTION
(thanks to @axyjo)

Issue: `plural()` is called only before `servers` is populated, so an "s" is never added to "connection" on the Storm web UI
Fix: call `plural()` again once data is fetched
