### PR TITLE
Enhanced edit feature 

### DIFF
--- a/storm/__init__.py
+++ b/storm/__init__.py
@@ -27,12 +27,11 @@ class Storm(object):
 
         return True
 
-    def edit_entry(self, name, host, user, port, id_file, custom_options=[]):
+    def edit_entry(self, name, **kwargs):
         if not self.is_host_in(name):
             raise StormValueError('{0} doesn\'t exists in your sshconfig. use storm add command to add.'.format(name))
 
-        options = self.get_options(host, user, port, id_file, custom_options)
-        self.ssh_config.update_host(name, options)
+        self.ssh_config.update_host(name, **kwargs)
         self.ssh_config.write_to_ssh_config()
 
         return True
@@ -100,7 +99,8 @@ class Storm(object):
         return options
 
     def is_host_in(self, host):
+	import re
         for host_ in self.ssh_config.config_data:
-            if host_.get("host") == host:
+            if host_.get("host") == host or re.match(host, host_.get("host")):
                 return True
         return False

--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -75,7 +75,7 @@ def add(name, connection_uri, id_file="", o=[]):
 
 
 @command('edit')
-def edit(name, connection_uri, id_file="", o=[]):
+def edit(name, connection_uri="", id_file="",  o=[]):
     """
     Edits the related entry in ssh config.
     """
@@ -84,8 +84,22 @@ def edit(name, connection_uri, id_file="", o=[]):
             name = " ".join(name.split(","))
 
         user, host, port = parse(connection_uri)
+        
+        settings = {}
+        settings.setdefault("user", user)
+        settings.setdefault("port", port)
 
-        storm_.edit_entry(name, host, user, port, id_file, o)
+        if id_file: 
+            settings["identityfile"] = id_file
+
+        if connection_uri: 
+            settings["hostname"] = connection_uri
+
+        for option in o:
+            k,v = option.split("=")
+            settings[k] = v 
+
+        storm_.edit_entry(name, **settings)
         print get_formatted_message(
             '"{0}" updated successfully.'.format(
                 name

--- a/storm/ssh_config.py
+++ b/storm/ssh_config.py
@@ -137,10 +137,11 @@ class ConfigParser(object):
 
         return self
 
-    def update_host(self, host, options):
-        for index, host_entry in enumerate(self.config_data):
-            if host_entry.get("host") == host:
-                self.config_data[index]["options"] = options
+    def update_host(self, host, **kwargs):
+        import re
+        for index, hostentry in enumerate(self.config_data):
+            if hostentry.get("host") == host or re.match(host, hostentry.get("host")):
+                self.config_data[index]["options"].update(kwargs)
 
         return self
 


### PR DESCRIPTION
Here are some enhancements that I think will be useful. 
1. Multiple edits via regular expression on host 

``` bash
vagrant@precise32:/vagrant$ python storm/ list
listing entries:
    google-01 -> vagrant@www1.google.com:22 
    [custom options] identityfile=/home/vagrant/.ssh/test

    google-02 -> vagrant@google.com:22 
    [custom options] identityfile=/home/vagrant/.ssh/test

vagrant@precise32:/vagrant$ python storm/ edit google-0[1-2] --o user=test
success  "google-0[1-2]" updated successfully.
```

Multiple edit modifies config of hosts who match regular expression

``` bash
vagrant@precise32:/vagrant$ python storm/ list
listing entries:
    google-01 -> test@www1.google.com:22 
    [custom options] identityfile=/home/vagrant/.ssh/test

    google-02 -> test@google.com:22 
    [custom options] identityfile=/home/vagrant/.ssh/test
```
1. Modified usage of edit; id_file and connection_uri are now optional. If they are not passed their values will not change. Saves some typing. 

``` bash
usage: storm edit [-h] [--connection_uri CONNECTION_URI] [--id_file ID_FILE]
                  [--o O]
                  name

positional arguments:
  name

optional arguments:
  -h, --help            show this help message and exit
  --connection_uri CONNECTION_URI
  --id_file ID_FILE
  --o O
```
