### PR TITLE
Missing `re` import

### DIFF
--- a/storm/ssh_config.py
+++ b/storm/ssh_config.py
@@ -6,6 +6,7 @@ from os.path import dirname
 from os.path import expanduser
 from os.path import exists
 from operator import itemgetter
+import re
 
 from paramiko.config import SSHConfig
 import six


### PR DESCRIPTION
Adding the missing import as reported in emre/storm#63
