### PR TITLE
Cannot add new entry with if a hostname is a substring of an existing entry's hostname 

### DIFF
--- a/storm/__init__.py
+++ b/storm/__init__.py
@@ -41,7 +41,7 @@ class Storm(object):
         return True
 
     def update_entry(self, name, **kwargs):
-        if not self.is_host_in(name):
+        if not self.is_host_in(name, regexp_match = True):
             raise StormValueError('{0} doesn\'t exists in your sshconfig. use storm add command to add.'.format(name))
 
         self.ssh_config.update_host(name, kwargs)
@@ -113,9 +113,9 @@ class Storm(object):
 
         return options
 
-    def is_host_in(self, host):
+    def is_host_in(self, host, regexp_match = False):
         import re
         for host_ in self.ssh_config.config_data:
-            if host_.get("host") == host or re.match(host, host_.get("host")):
+            if host_.get("host") == host or (regexp_match and re.match(host, host_.get("host"))):
                 return True
         return False

--- a/tests.py
+++ b/tests.py
@@ -43,10 +43,11 @@ class StormTests(unittest.TestCase):
 
     def test_add_host(self):
         self.storm.add_entry('google', 'google.com', 'root', '22', '/tmp/tmp.pub')
+        self.storm.add_entry('goog', 'google.com', 'root', '22', '/tmp/tmp.pub')
         self.storm.ssh_config.write_to_ssh_config()
 
         for item in self.storm.ssh_config.config_data:
-            if item.get("host") == 'google':
+            if item.get("host") == 'google' or item.get("host") == 'goog':
                 self.assertEqual(item.get("options").get("port"), '22')
                 self.assertEqual(item.get("options").get("identityfile"), '/tmp/tmp.pub')
 


### PR DESCRIPTION
I created this bug and here is a patch for it as well as a unit test.  When an entry is added with a hostname that is a substring of an existing entry's hostname, the former is not added because storm thinks it exists already. 

For example: 

``` bash
$ storm list
listing entries:

    google-01 -> vagrant@google.com:24

    google-02 -> vagrant@google.com:22


$ storm add goog vagrant@google.com
error    goog is already in your sshconfig. use storm edit command to modify.
```
