### PR TITLE
Add 'pretty'  option to ConfigParser output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='stormssh',
-    version='0.6.5',
+    version='0.6.5-neverware',
     packages=find_packages(),
     package_data={'storm': ['templates/*.html', 'static/css/*.css',
                             'static/css/themes/storm/*.css', 'static/css/themes/storm/img/*.png',

--- a/storm/__init__.py
+++ b/storm/__init__.py
@@ -25,14 +25,14 @@ class Storm(object):
         self.ssh_config.load()
         self.defaults = self.ssh_config.defaults
 
-    def add_entry(self, name, host, user, port, id_file, custom_options=[]):
+    def add_entry(self, name, host, user, port, id_file, custom_options=[], pretty=False):
         if self.is_host_in(name):
             raise ValueError(ERRORS["already_in"].format(name))
 
         options = self.get_options(host, user, port, id_file, custom_options)
 
         self.ssh_config.add_host(name, options)
-        self.ssh_config.write_to_ssh_config()
+        self.ssh_config.write_to_ssh_config(pretty)
 
         return True
 
@@ -62,12 +62,12 @@ class Storm(object):
 
         return True
 
-    def update_entry(self, name, **kwargs):
+    def update_entry(self, name, pretty, **kwargs):
         if not self.is_host_in(name, regexp_match=True):
             raise ValueError(ERRORS["not_found"].format(name))
 
         self.ssh_config.update_host(name, kwargs, use_regex=True)
-        self.ssh_config.write_to_ssh_config()
+        self.ssh_config.write_to_ssh_config(pretty)
 
         return True
 

--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -30,7 +30,7 @@ def version():
 
 
 @command('add')
-def add(name, connection_uri, id_file="", o=[], config=None):
+def add(name, connection_uri, id_file="", o=[], config=None, pretty=False):
     """
     Adds a new entry to sshconfig.
     """
@@ -48,7 +48,7 @@ def add(name, connection_uri, id_file="", o=[], config=None):
             port=get_default("port", storm_.defaults)
         )
 
-        storm_.add_entry(name, host, user, port, id_file, o)
+        storm_.add_entry(name, host, user, port, id_file, o, pretty)
 
         print(get_formatted_message('{0} added to your ssh config. you can connect it by typing "ssh {0}".'.format(
 
@@ -108,7 +108,7 @@ def edit(name, connection_uri, id_file="", o=[], config=None):
         print(get_formatted_message(error, 'error'), file=sys.stderr)
 
 @command('update')
-def update(name, connection_uri="", id_file="", o=[], config=None):
+def update(name, connection_uri="", id_file="", o=[], config=None, pretty=False):
     """
     Enhanced version of the edit command featuring multiple edits using regular expressions to match entries
     """
@@ -123,7 +123,7 @@ def update(name, connection_uri="", id_file="", o=[], config=None):
         settings[k] = v
 
     try:
-        storm_.update_entry(name, **settings)
+        storm_.update_entry(name, pretty, **settings)
         print(get_formatted_message(
             '"{0}" updated successfully.'.format(
                 name

--- a/storm/kommandr.py
+++ b/storm/kommandr.py
@@ -143,6 +143,7 @@ class prog(object):
                                           reversed(spec.defaults or []),
                                           fillvalue=self._POSITIONAL())))
         for k, v in opts:
+            # print k,v
             argopts = getattr(func, 'argopts', {})
             args, kwargs = argopts.get(k, ([], {}))
             args = list(args)
@@ -152,6 +153,9 @@ class prog(object):
                 kwargs.update({
                     'action': 'append',
                 })
+            if k == "pretty":
+                args = ['--pretty']
+                kwargs.update({'action': 'store_true', 'default': False})
             if is_positional:
                 if options:
                     args = options

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -193,7 +193,7 @@ class ConfigParser(object):
 
         return self
 
-    def dump(self, pretty=True):
+    def dump(self, pretty=False):
         if len(self.config_data) < 1:
             return
 
@@ -225,7 +225,7 @@ class ConfigParser(object):
 
         return file_content
 
-    def write_to_ssh_config(self, pretty=True):
+    def write_to_ssh_config(self, pretty=False):
         with open(self.ssh_config_file, 'w+') as f:
             data = self.dump(pretty)
             if data:

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -205,6 +205,9 @@ class ConfigParser(object):
         file_content = ""
         self.config_data = sorted(self.config_data, key=itemgetter("order"))
 
+        if pretty:
+            entries = []
+
         for host_item in self.config_data:
             if host_item.get("type") in ['comment', 'empty_line']:
                 file_content += host_item.get("value") + "\n"
@@ -225,9 +228,12 @@ class ConfigParser(object):
                         key, value
                     )
             if pretty:
-                host_item_content += "\n"
-            file_content += host_item_content
+                entries.append(host_item_content)
+            else:
+                file_content += host_item_content
 
+        if pretty:
+            file_content = '\n'.join(entries)
         return file_content
 
     def write_to_ssh_config(self, pretty=False):

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -154,6 +154,11 @@ class ConfigParser(object):
   
         return self
 
+    def strict_search(self, search_string):
+        for host_entry in self.config_data:
+            if host_entry.get("host") == search_string:
+                return host_entry
+
     def search_host(self, search_string):
         results = []
         for host_entry in self.config_data:

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -211,6 +211,9 @@ class ConfigParser(object):
         for host_item in self.config_data:
             if host_item.get("type") in ['comment', 'empty_line']:
                 file_content += host_item.get("value") + "\n"
+                if host_item.get("type") == 'comment':
+                    entries.append(host_item.get("value"))
+                    continue
                 continue
             host_item_content = "Host {0}\n".format(host_item.get("host"))
             for key, value in six.iteritems(host_item.get("options")):

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -210,14 +210,14 @@ class ConfigParser(object):
                     sub_content = ""
                     for value_ in value:
                         sub_content += "    {0} {1}\n".format(
-                            key, value_
+                            key.title(), value_
                         )
                     host_item_content += sub_content
                 else:
                     host_item_content += "    {0} {1}\n".format(
-                        key, value
+                        key.title(), value
                     )
-            file_content += host_item_content
+            file_content += host_item_content + "\n"
 
         return file_content
 

--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -193,7 +193,7 @@ class ConfigParser(object):
 
         return self
 
-    def dump(self):
+    def dump(self, pretty=True):
         if len(self.config_data) < 1:
             return
 
@@ -209,21 +209,25 @@ class ConfigParser(object):
                 if isinstance(value, list):
                     sub_content = ""
                     for value_ in value:
+                        key = key.title() if pretty else key
                         sub_content += "    {0} {1}\n".format(
-                            key.title(), value_
+                            key, value_
                         )
                     host_item_content += sub_content
                 else:
+                    key = key.title() if pretty else key
                     host_item_content += "    {0} {1}\n".format(
-                        key.title(), value
+                        key, value
                     )
-            file_content += host_item_content + "\n"
+            if pretty:
+                host_item_content += "\n"
+            file_content += host_item_content
 
         return file_content
 
-    def write_to_ssh_config(self):
+    def write_to_ssh_config(self, pretty=True):
         with open(self.ssh_config_file, 'w+') as f:
-            data = self.dump()
+            data = self.dump(pretty)
             if data:
                 f.write(data)
         return self


### PR DESCRIPTION
ConfigParser().dump(pretty=True) / ConfigParser().write_to_ssh_config(pretty=True) results in entry keys getting titlecased and separated by newlines, i.e.:

	Host myhost
		Hostname localhost
		User iamauser
		Port 1234