### PR TITLE
Check deleted_field in options before del it

### DIFF
--- a/storm/parsers/ssh_config_parser.py
+++ b/storm/parsers/ssh_config_parser.py
@@ -153,12 +153,14 @@ class ConfigParser(object):
             if host_entry.get("host") == host or \
                     (use_regex and re.match(host, host_entry.get("host"))):
 
+                opts = self.config_data[index]["options"]
                 if 'deleted_fields' in options:
                     deleted_fields = options.pop("deleted_fields")
                     for deleted_field in deleted_fields:
-                        del self.config_data[index]["options"][deleted_field]
+                        if deleted_field in opts:
+                            del opts[deleted_field]
 
-                self.config_data[index]["options"].update(options)
+                opts.update(options)
 
         return self
 


### PR DESCRIPTION
This commit is aimed at fixing `PUT /edit 400` problem when edit an item
in web interface. When editing in web, if id_file is left empty, it will
cause `ConfigParser.update_host` to try deleting `identityfile` in `options`,
but if `identityfile` is not in `options` for whatever reason,
`update_host` will raise KeyError exception hence /edit will fail with 400.
By checking each key in options before `del`, KeyError could be avoided.