### PR TITLE
Add completion to PKGBUILD

### DIFF
--- a/contrib/archlinux/PKGBUILD
+++ b/contrib/archlinux/PKGBUILD
@@ -28,6 +28,7 @@ build() {
 package() {
   cd "$srcdir/storm"
   python setup.py install --root="$pkgdir/"
+  install -Dm644 $srcdir/storm/contrib/bash-completion/stormssh $pkgdir/usr/share/bash-completion/completions/storm
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
But Why the PKGBUILD on github repo difference from AUR?
https://github.com/emre/storm/blob/master/contrib/archlinux/PKGBUILD
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-stormssh