### PR TITLE
Change to unpriviledged user install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On Ubuntu 16.04, you need install libssl-dev and libffi-dev (sudo apt-get instal
 #### installation
 
 ```bash
-$ [sudo] pip install stormssh
+$ pip install --user stormssh
 ```
 or if you like 90s:
 ```bash


### PR DESCRIPTION
It would be better to recommend people to install without sudo by using the `--user` flag.