### PR TITLE
Update collections import for Python 3.10

### DIFF
--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -17,6 +17,10 @@ from storm.defaults import get_default
 from storm import __version__
 
 import sys
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 def get_storm_instance(config_file=None):
     return Storm(config_file)
@@ -224,7 +228,7 @@ def list(config=None):
                                 result += " {0}".format(custom_options)
                             extra = True
 
-                            if isinstance(value, collections.Sequence):
+                            if isinstance(value, collections_abc.Sequence):
                                 if isinstance(value, builtins.list):
                                     value = ",".join(value)
                                     

--- a/storm/kommandr.py
+++ b/storm/kommandr.py
@@ -13,7 +13,10 @@ try:
     from itertools import izip_longest
 except ImportError:
     from itertools import zip_longest as izip_longest
-import collections
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 import six
 
@@ -95,7 +98,7 @@ class prog(object):
 
     def command(self, *args, **kwargs):
         """Convenient decorator simply creates corresponding command"""
-        if len(args) == 1 and isinstance(args[0], collections.Callable):
+        if len(args) == 1 and isinstance(args[0], collections_abc.Callable):
             return self._generate_command(args[0])
         else:
             def _command(func):


### PR DESCRIPTION
Python 3.10 deprecated collections classes generic in favour of `collections.abc`.