### PR TITLE
fix: generic code to test Callable

### DIFF
--- a/storm/kommandr.py
+++ b/storm/kommandr.py
@@ -13,7 +13,13 @@ try:
     from itertools import izip_longest
 except ImportError:
     from itertools import zip_longest as izip_longest
-import collections
+
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 
 import six
 
@@ -95,7 +101,7 @@ class prog(object):
 
     def command(self, *args, **kwargs):
         """Convenient decorator simply creates corresponding command"""
-        if len(args) == 1 and isinstance(args[0], collections.Callable):
+        if len(args) == 1 and isinstance(args[0], Callable):
             return self._generate_command(args[0])
         else:
             def _command(func):


### PR DESCRIPTION
I've just copied/pasted the code seen in:

- [Deprecation warning for collections.Callable under Python 3.7](https://github.com/rbarrois/xworkflows/issues/16)