### PR TITLE
updated collections call

### DIFF
--- a/storm/__main__.py
+++ b/storm/__main__.py
@@ -224,7 +224,7 @@ def list(config=None):
                                 result += " {0}".format(custom_options)
                             extra = True
 
-                            if isinstance(value, collections.Sequence):
+                            if isinstance(value, collections.abc.Sequence):
                                 if isinstance(value, builtins.list):
                                     value = ",".join(value)
                                     

--- a/storm/kommandr.py
+++ b/storm/kommandr.py
@@ -95,7 +95,7 @@ class prog(object):
 
     def command(self, *args, **kwargs):
         """Convenient decorator simply creates corresponding command"""
-        if len(args) == 1 and isinstance(args[0], collections.Callable):
+        if len(args) == 1 and isinstance(args[0], collections.abc.Callable):
             return self._generate_command(args[0])
         else:
             def _command(func):


### PR DESCRIPTION
Python3.10 moved `collections.callable` and `collections.sequence` to `collections.abc.callable` and `collections.abc.sqeuence`